### PR TITLE
Patches to get scripts working

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ https://raw.githubusercontent.com/sandervanvugt/cka/master/setup-kubetools.sh
 * Makes use of the following Centos 7 Vagrant image as the base OS:  
 centos/7
 
-* Due to how networking is configured in Vagrant, you will need to tell your master node to listen on the "control" node IP (192.168.4.110) vs the default Vagrant IP.
+* Due to how networking is configured in Vagrant, you will need to tell your master node to listen on the "control" node IP (192.168.56.110) vs the default Vagrant IP.
 
 * This can be done via kubeadm when initializing the "control" master node:  
-### $ sudo kubeadm init --apiserver-advertise-address=192.168.4.110
+### $ sudo kubeadm init --apiserver-advertise-address=192.168.56.110
 
 -------------------------
 Example Cluster Setup:
@@ -65,7 +65,7 @@ $ vagrant up
 
 ### --- EXAMPLE CONTROL (MASTER) KUBERNETES NODE SETUP ---  
 $ vagrant ssh control  
-$ sudo kubeadm init --apiserver-advertise-address=192.168.4.110  
+$ sudo kubeadm init --apiserver-advertise-address=192.168.56.110  
   
 To start using your cluster, you need to run the following as a regular user:  
   
@@ -75,7 +75,7 @@ To start using your cluster, you need to run the following as a regular user:
   
 Then you can join any number of worker nodes by running the following on each as root:  
   
-kubeadm join 192.168.4.110:6443 --token btnom1.grmjn91si3j7w9kx \  
+kubeadm join 192.168.56.110:6443 --token btnom1.grmjn91si3j7w9kx \  
     --discovery-token-ca-cert-hash sha256:ffc9f54f15bfc0822ac694739e6a2f26413108414d77563b82be3479a7af66f2  
   
 $ mkdir -p $HOME/.kube  
@@ -90,15 +90,15 @@ $ exit
   
 ### --- EXAMPLE WORKER KUBERNETES NODE SETUP ---  
 $ vagrant ssh worker1  
-$ sudo kubeadm join 192.168.4.110:6443 --token btnom1.grmjn91si3j7w9kx \  
+$ sudo kubeadm join 192.168.56.110:6443 --token btnom1.grmjn91si3j7w9kx \  
     --discovery-token-ca-cert-hash sha256:ffc9f54f15bfc0822ac694739e6a2f26413108414d77563b82be3479a7af66f2  
   
 $ vagrant ssh worker2  
-$ sudo kubeadm join 192.168.4.110:6443 --token btnom1.grmjn91si3j7w9kx \  
+$ sudo kubeadm join 192.168.56.110:6443 --token btnom1.grmjn91si3j7w9kx \  
     --discovery-token-ca-cert-hash sha256:ffc9f54f15bfc0822ac694739e6a2f26413108414d77563b82be3479a7af66f2  
   
 $ vagrant ssh worker3  
-$ sudo kubeadm join 192.168.4.110:6443 --token btnom1.grmjn91si3j7w9kx \  
+$ sudo kubeadm join 192.168.56.110:6443 --token btnom1.grmjn91si3j7w9kx \  
     --discovery-token-ca-cert-hash sha256:ffc9f54f15bfc0822ac694739e6a2f26413108414d77563b82be3479a7af66f2  
 
 This node has joined the cluster:  

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-ENV['VAGRANT_NO_PARALLEL'] = 'yes'
-
 Vagrant.configure(2) do |config|
 
   # Kubernetes Master Server
@@ -12,12 +10,20 @@ Vagrant.configure(2) do |config|
     control.vm.network "private_network", ip: "192.168.56.110"
     control.vm.provider "virtualbox" do |v|
       v.name = "control"
-      v.memory = 2048
+      v.memory = 4096
       v.cpus = 2
     end
     control.vm.provision "shell", path: "prereqs.sh"
     control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-container.sh"
     control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-kubetools.sh"
+    control.vm.provision "shell", inline: "swapoff -a"
+    control.vm.provision "shell", inline: "echo 192.168.56.111 worker1.example.com >> /etc/hosts"
+    control.vm.provision "shell", inline: "echo 192.168.56.112 worker2.example.com >> /etc/hosts"
+    control.vm.provision "shell", inline: "echo 192.168.56.113 worker3.example.com >> /etc/hosts"
+    control.vm.provision "shell", inline: "echo 192.168.56.110 control.example.com >> /etc/hosts"
+    control.vm.provision "shell", inline: "kubeadm init --apiserver-advertise-address 192.168.56.110"
+    control.vm.provision "shell", inline: "mkdir /home/vagrant/.kube && cp /etc/kubernetes/admin.conf /home/vagrant/.kube/config && chown -R vagrant:vagrant /home/vagrant/.kube"
+#    control.vm.provision "shell", inline: "sudo -u vagrant \"sh -c \'kubectl apply -f \"https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')&env.WEAVE_MTU=1337\" \'\""
   end
 
   NodeCount = 3
@@ -30,12 +36,17 @@ Vagrant.configure(2) do |config|
       workernode.vm.network "private_network", ip: "192.168.56.11#{i}"
       workernode.vm.provider "virtualbox" do |v|
         v.name = "worker#{i}"
-        v.memory = 1024
+        v.memory = 4096
         v.cpus = 1
       end
       workernode.vm.provision "shell", path: "prereqs.sh"
+      workernode.vm.provision "shell", inline: "echo 192.168.56.111 worker1.example.com >> /etc/hosts"
+      workernode.vm.provision "shell", inline: "echo 192.168.56.112 worker2.example.com >> /etc/hosts"
+      workernode.vm.provision "shell", inline: "echo 192.168.56.113 worker3.example.com >> /etc/hosts"
+      workernode.vm.provision "shell", inline: "echo 192.168.56.110 control.example.com >> /etc/hosts"
       workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-container.sh"
       workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-kubetools.sh"
+      workernode.vm.provision "shell", inline: "swapoff -a"
     end
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(2) do |config|
       v.cpus = 2
     end
     control.vm.provision "shell", path: "prereqs.sh"
-    control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-docker.sh"
+    control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-container.sh"
     control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-kubetools.sh"
   end
 
@@ -34,7 +34,7 @@ Vagrant.configure(2) do |config|
         v.cpus = 1
       end
       workernode.vm.provision "shell", path: "prereqs.sh"
-      workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-docker.sh"
+      workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-container.sh"
       workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-kubetools.sh"
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure(2) do |config|
   config.vm.define "control" do |control|
     control.vm.box = "centos/7"
     control.vm.hostname = "control.example.com"
-    control.vm.network "private_network", ip: "192.168.4.110"
+    control.vm.network "private_network", ip: "192.168.56.110"
     control.vm.provider "virtualbox" do |v|
       v.name = "control"
       v.memory = 2048
@@ -27,7 +27,7 @@ Vagrant.configure(2) do |config|
     config.vm.define "worker#{i}" do |workernode|
       workernode.vm.box = "centos/7"
       workernode.vm.hostname = "worker#{i}.example.com"
-      workernode.vm.network "private_network", ip: "192.168.4.11#{i}"
+      workernode.vm.network "private_network", ip: "192.168.56.11#{i}"
       workernode.vm.provider "virtualbox" do |v|
         v.name = "worker#{i}"
         v.memory = 1024

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,8 +16,8 @@ Vagrant.configure(2) do |config|
       v.cpus = 2
     end
     control.vm.provision "shell", path: "prereqs.sh"
-    control.vm.provision "shell", path: "https://raw.githubusercontent.com/sandervanvugt/cka/master/setup-docker.sh"
-    control.vm.provision "shell", path: "https://raw.githubusercontent.com/sandervanvugt/cka/master/setup-kubetools.sh"
+    control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-docker.sh"
+    control.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-kubetools.sh"
   end
 
   NodeCount = 3
@@ -34,8 +34,8 @@ Vagrant.configure(2) do |config|
         v.cpus = 1
       end
       workernode.vm.provision "shell", path: "prereqs.sh"
-      workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/sandervanvugt/cka/master/setup-docker.sh"
-      workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/sandervanvugt/cka/master/setup-kubetools.sh"
+      workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-docker.sh"
+      workernode.vm.provision "shell", path: "https://raw.githubusercontent.com/gwynforthewyn/cka/master/setup-kubetools.sh"
     end
   end
 


### PR DESCRIPTION
I realise you may not be maintaining these, but just in case, there are two changes needed to get Vagrant working for this course:

- first, vagrant's changed its notion of what ip address ranges are good to use with host-only networking. This is documented in https://www.virtualbox.org/manual/ch06.html#network_hostonly

- second, the upstream CKA scripts needed a minor tweak to no longer check gpg, due to a known issue with centos7. I changed this in my own fork of the cka scripts from sandervanvugt and patched the vagrantfile to use my fork 